### PR TITLE
bump pandas version (fix install error)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.3
-pandas==2.0.3
+pandas==2.2.3
 pdb-tools==2.5.0
 nextflow==23.4.2
 virtualenv==20.23.1


### PR DESCRIPTION
Fixes the following error on `pip install pandas==2.0.3`

```
ERROR: Failed to build installable wheels for some pyproject.toml based projects (pandas)
```