### PR TITLE
Fixes for unidoc / chainsaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Demo: Domain Annotation Pipeline
+
 Data pipeline to provide consensus domain annotations for protein structures
 
-## Install
+## Install (with docker)
 
 Install Nextflow
 
@@ -25,5 +26,5 @@ docker compose build
 ## Run
 
 ```
-nextflow run workflows/annotate.nf
+nextflow run workflows/annotate.nf -c nextflow-with-docker.config
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   # cath-af-cli:
   #   build: docker/cath-af-cli
 
+  script:
+    build: docker/script
+
   pdb-tools:
     build: docker/pdb-tools
 

--- a/docker/UniDoc/Dockerfile
+++ b/docker/UniDoc/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -12,5 +12,10 @@ WORKDIR /app
 RUN wget --no-check-certificate http://yanglab.qd.sdu.edu.cn/UniDoc/download/UniDoc.tgz && tar xvf UniDoc.tgz
 
 WORKDIR /app/UniDoc
+
+# unidoc expects to find all the executables in the current directory
+RUN cp bin/* . && rm -rf bin
+
+ENV PATH="$PATH:."
 
 CMD ["/bin/bash"]

--- a/docker/script/Dockerfile
+++ b/docker/script/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim-buster
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-         vim wget gzip tar git\
+  vim wget gzip tar git\
   && apt-get autoremove -yqq --purge \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
@@ -10,6 +10,8 @@ RUN apt-get update \
 WORKDIR /app
 
 COPY requirements.txt requirements.txt
+
+COPY combine_results.py combine_results.py
 
 RUN pip install --upgrade pip wheel && pip install -r requirements.txt
 

--- a/docker/script/combine_results.py
+++ b/docker/script/combine_results.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 MERIZO_COLS = 'af_chain_id nres nres_dom nres_ndr ndom pIoU runtime result'.split()
 UNIDOC_COLS = 'af_chain_id result'.split()
-CHAINSAW_COLS = 'af_chain_id sequence_md5	nres ndom	result uncertainty'.split()
+CHAINSAW_COLS = 'af_chain_id sequence_md5	nres ndom	result uncertainty time_sec'.split()
 OUTPUT_COLS = {
     'af_chain_id': 'AlphaFold_ID',
     'result_chainsaw': 'Chainsaw',
@@ -21,30 +21,38 @@ OUTPUT_COLS = {
 @click.option('--output', '-o', 'output_file', 
               required=True, help='Output result file path (TSV)')
 def run(merizo_file, unidoc_file, chainsaw_file, output_file):
+
+    # read merizo results
     merizo_df = pd.read_csv(merizo_file, sep='\t', header=None, names=MERIZO_COLS)
     merizo_df = normalise_df(merizo_df)
     merizo_df.rename(columns={'result': 'result_merizo'}, inplace=True)
     
+    # read unidoc results
     unidoc_df = pd.read_csv(unidoc_file, sep='\t', header=None, names=UNIDOC_COLS)
     unidoc_df = normalise_df(unidoc_df)
     unidoc_df.rename(columns={'result': 'result_unidoc'}, inplace=True)
-    
+
+    # read chainsaw results
+    chainsaw_df = pd.read_csv(chainsaw_file, sep='\t', header=None, names=CHAINSAW_COLS)
+    chainsaw_df = normalise_df(chainsaw_df)
+    chainsaw_df.rename(columns={'result': 'result_chainsaw'}, inplace=True)
+
+    # merge results
     result_df = merizo_df.merge(unidoc_df, on='af_chain_id', how='outer')
+    result_df = result_df.merge(chainsaw_df, on='af_chain_id', how='outer')
 
-    if chainsaw_file:
-        chainsaw_df = pd.read_csv(chainsaw_file, sep='\t', header=None, names=CHAINSAW_COLS)
-        chainsaw_df = normalise_df(chainsaw_df)
-        chainsaw_df.rename(columns={'result': 'result_chainsaw'}, inplace=True)
-        result_df = result_df.merge(chainsaw_df, on='af_chain_id', how='outer')
-    else:
-        result_df['result_chainsaw'] = [None] * result_df.shape[0]
-
+    # format output
     result_df = result_df[OUTPUT_COLS.keys()].rename(columns=OUTPUT_COLS)
     result_df.to_csv(output_file, sep='\t', index=False, header=True)
+    
 
 def normalise_df(df):
     # index by file stem (no suffix)
     df['af_chain_id'] = df['af_chain_id'].str.replace('.pdb', '').str.replace('.cif', '')
+    bad_matches_idx = df['af_chain_id'].str.match(r'(?!AF-)')
+    if bad_matches_idx.any():
+        bad_matches = df.loc[bad_matches_idx, 'af_chain_id'].unique()
+        raise RuntimeError(f"Invalid AlphaFold ID: {bad_matches}")
     return df
 
 

--- a/docker/script/requirements.txt
+++ b/docker/script/requirements.txt
@@ -1,0 +1,2 @@
+click
+pandas

--- a/nextflow-with-docker.config
+++ b/nextflow-with-docker.config
@@ -11,7 +11,7 @@ process {
     withName:run_chainsaw {
         container = 'domain-annotation-pipeline-chainsaw'
     }
-    withName:combine_results {
+    withName:collect_results {
         container = 'domain-annotation-pipeline-script'
     }
 }
@@ -20,6 +20,6 @@ params.unidoc_dir = "/app/UniDoc"
 params.chainsaw_script = "python3 /app/chainsaw/get_predictions.py"
 params.merizo_script = "python3 /app/Merizo/predict.py"
 params.unidoc_script = "python3 /app/UniDoc/Run_UniDoc_from_scratch_structure.py"
-params.combine_script = "python3 /app/script/combine_results.py"
+params.combine_script = "python3 /app/combine_results.py"
 
 docker.enabled = true

--- a/workflows/annotate.nf
+++ b/workflows/annotate.nf
@@ -102,8 +102,11 @@ process run_unidoc {
     path 'unidoc_results.csv'
 
     """
-    # UniDoc expects to be run from its own directory
-    ln -s ${params.unidoc_dir}/bin bin
+    set -e
+
+    # UniDoc expects to be run from current directory
+    ln -s ${params.unidoc_dir}/stride .
+    ln -s ${params.unidoc_dir}/UniDoc_struct .
 
     for pdb_file in *.pdb; do
         file_stem=\${pdb_file%.pdb}


### PR DESCRIPTION
* use full python container for unidoc (rather than slim)
* link unidoc executables into current working directory (unidoc expects)
* add column for chainsaw output
* check for correctly formatted ids in `collect_results` 