### PR TITLE
fix PDB choppings from discontinuous domains

### DIFF
--- a/docker/pdb-tools/chop_pdbs.py
+++ b/docker/pdb-tools/chop_pdbs.py
@@ -21,6 +21,7 @@ def parse_domain_boundaries(boundary_str, level):
 
 def run_pdb_selres(pdb_file, start, end, output_file, append=False):
     mode = 'a' if append else 'w'
+    ignore_lines = ['END', 'ENDMDL', 'MODEL']
     with open(output_file, mode) as out:
         result = subprocess.run(
             ['python', '-m', 'pdbtools.pdb_selres', f'-{start}:{end}', pdb_file],
@@ -28,7 +29,7 @@ def run_pdb_selres(pdb_file, start, end, output_file, append=False):
             text=True,
             check=True
         )
-        lines = [line for line in result.stdout.splitlines() if line.strip() != 'END']
+        lines = [line for line in result.stdout.splitlines() if line.split()[0] not in ignore_lines]
         out.write('\n'.join(lines) + '\n')
 
 def main(consensus_file, output_dir):

--- a/modules/run_stride.nf
+++ b/modules/run_stride.nf
@@ -12,7 +12,6 @@ process run_stride {
     script:
     """
     for f in *.pdb; do
-        awk '!/^MODEL/ && !/^ENDMDL/' \$f > temp && mv temp \$f
         stride \$f > \${f%.pdb}.stride 2> \${f%.pdb}.stride.err || { 
         echo "STRIDE failed on \$f, see \${f%.pdb}.stride.err" 
         continue 


### PR DESCRIPTION
fixes an issue with `chop_pdb.py` that allowed `ENDMDL` lines to be inserted into the chopped PDB files (which broke various programs downstream) 