### PR TITLE
Corrects duplication bug and deals with foldseek non-uniprot ids

### DIFF
--- a/docker/cath-af-cli/Dockerfile
+++ b/docker/cath-af-cli/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     build-essential \
     cmake \
     git \
+    unzip \
     wget \
     procps \
     zlib1g-dev \
@@ -15,8 +16,9 @@ RUN apt-get update && \
 # Install STRIDE
 RUN mkdir -p /opt/stride && \
     cd /opt/stride && \
-    wget --no-check-certificate https://webclu.bio.wzw.tum.de/stride/stride.tar.gz && \
-    tar -zxf stride.tar.gz && \
+    wget https://github.com/heiniglab/stride/archive/refs/heads/main.zip && \
+    unzip main.zip && \
+    cd stride-main && \
     make && \
     cp stride /usr/local/bin/stride
 

--- a/docker/script/fetch_uniprot_data.py
+++ b/docker/script/fetch_uniprot_data.py
@@ -44,9 +44,6 @@ def clean_accessions(accessions):
             continue
         clean.append(a)
 
-    if not clean:
-        raise ValueError("No valid UniProt accessions after cleaning input")
-
     return clean
 
 
@@ -221,9 +218,24 @@ def fetch_uniprot_batch(accessions):
     Returns list of dicts with keys:
       accession, proteome_id, tax_common_name, tax_scientific_name, tax_lineage
     """
-    ids = clean_accessions(accessions)
-    print(f"[INFO] Processing batch of {len(ids)} IDs")
+    original_ids = [a.strip() for a in accessions if a.strip()]
+    ids = clean_accessions(original_ids)
+    print(f"[INFO] Processing batch of {len(original_ids)} input IDs")
+    print(f"[INFO] Valid UniProt-like IDs in batch: {len(ids)}")
+    rows = []
 
+    # If there are no valid UniProt-like IDs, return blank rows for all original IDs
+    if not ids:
+        print("[INFO] No valid UniProt accessions in this batch; writing blank rows.")
+        for acc in original_ids:
+            rows.append({
+                "accession": acc,
+                "proteome_id": "",
+                "tax_common_name": "",
+                "tax_scientific_name": "",
+                "tax_lineage": "",
+            })
+        return rows
     # Submit mapping job with retry logic
     max_submit_retries = 3
     for submit_attempt in range(max_submit_retries):
@@ -237,17 +249,41 @@ def fetch_uniprot_batch(accessions):
                 time.sleep(2 ** submit_attempt)
             else:
                 print("[ERROR]   Skipping this batch due to repeated failures.")
-                return []
+                for acc in original_ids:
+                    rows.append({
+                        "accession": acc,
+                        "proteome_id": "",
+                        "tax_common_name": "",
+                        "tax_scientific_name": "",
+                        "tax_lineage": "",
+                    })
+                return rows
     else:
         # If we exited the loop without setting job_id, skip batch
-        print("[ERROR]   Could not obtain job_id, skipping batch.")
-        return []
+        print("[ERROR]   Could not obtain job_id, writing blank rows for this batch.")
+        for acc in original_ids:
+            rows.append({
+                "accession": acc,
+                "proteome_id": "",
+                "tax_common_name": "",
+                "tax_scientific_name": "",
+                "tax_lineage": "",
+            })
+        return rows
     tsv_text = download_mapping_results(job_id)
     mapped = parse_mapping_tsv(tsv_text)
 
-    rows = []
-
-    for acc in ids:
+    for acc in original_ids:
+        # Non-UniProt-like IDs get blank rows
+        if acc not in ids:
+            rows.append({
+                "accession": acc,
+                "proteome_id": "",
+                "tax_common_name": "",
+                "tax_scientific_name": "",
+                "tax_lineage": "",
+            })
+            continue
         entry = mapped.get(acc)
         if entry is None:
             rows.append({

--- a/docker/script/fetch_uniprot_data.py
+++ b/docker/script/fetch_uniprot_data.py
@@ -218,8 +218,18 @@ def fetch_uniprot_batch(accessions):
     Returns list of dicts with keys:
       accession, proteome_id, tax_common_name, tax_scientific_name, tax_lineage
     """
+    def blank_row(acc):
+        return {
+            "accession": acc,
+            "proteome_id": "",
+            "tax_common_name": "",
+            "tax_scientific_name": "",
+            "tax_lineage": "",
+        }
+
     original_ids = [a.strip() for a in accessions if a.strip()]
     ids = clean_accessions(original_ids)
+    ids_set = set(ids)
     print(f"[INFO] Processing batch of {len(original_ids)} input IDs")
     print(f"[INFO] Valid UniProt-like IDs in batch: {len(ids)}")
     rows = []
@@ -227,14 +237,7 @@ def fetch_uniprot_batch(accessions):
     # If there are no valid UniProt-like IDs, return blank rows for all original IDs
     if not ids:
         print("[INFO] No valid UniProt accessions in this batch; writing blank rows.")
-        for acc in original_ids:
-            rows.append({
-                "accession": acc,
-                "proteome_id": "",
-                "tax_common_name": "",
-                "tax_scientific_name": "",
-                "tax_lineage": "",
-            })
+        rows.extend(blank_row(acc) for acc in original_ids)
         return rows
     # Submit mapping job with retry logic
     max_submit_retries = 3
@@ -249,50 +252,24 @@ def fetch_uniprot_batch(accessions):
                 time.sleep(2 ** submit_attempt)
             else:
                 print("[ERROR]   Skipping this batch due to repeated failures.")
-                for acc in original_ids:
-                    rows.append({
-                        "accession": acc,
-                        "proteome_id": "",
-                        "tax_common_name": "",
-                        "tax_scientific_name": "",
-                        "tax_lineage": "",
-                    })
+                rows.extend(blank_row(acc) for acc in original_ids)
                 return rows
     else:
         # If we exited the loop without setting job_id, skip batch
         print("[ERROR]   Could not obtain job_id, writing blank rows for this batch.")
-        for acc in original_ids:
-            rows.append({
-                "accession": acc,
-                "proteome_id": "",
-                "tax_common_name": "",
-                "tax_scientific_name": "",
-                "tax_lineage": "",
-            })
+        rows.extend(blank_row(acc) for acc in original_ids)
         return rows
     tsv_text = download_mapping_results(job_id)
     mapped = parse_mapping_tsv(tsv_text)
 
     for acc in original_ids:
         # Non-UniProt-like IDs get blank rows
-        if acc not in ids:
-            rows.append({
-                "accession": acc,
-                "proteome_id": "",
-                "tax_common_name": "",
-                "tax_scientific_name": "",
-                "tax_lineage": "",
-            })
+        if acc not in ids_set:
+            rows.append(blank_row(acc))
             continue
         entry = mapped.get(acc)
         if entry is None:
-            rows.append({
-                "accession": acc,
-                "proteome_id": "",
-                "tax_common_name": "",
-                "tax_scientific_name": "",
-                "tax_lineage": "",
-            })
+            rows.append(blank_row(acc))
             continue
 
         tax_id = entry["tax_id"]
@@ -324,7 +301,7 @@ def fetch_uniprot_batch(accessions):
             "proteome_id": proteome_id,
             "tax_common_name": tax_common_name,
             "tax_scientific_name": tax_scientific_name,
-            "tax_lineage": lineage.replace(";", ";"),
+            "tax_lineage": lineage,
         })
 
     return rows

--- a/foldseek/bin/format_fs_output.py
+++ b/foldseek/bin/format_fs_output.py
@@ -18,7 +18,6 @@ OUTPUT_COLUMNS = [
     'qcov',
     'tcov',
 ]
-# WRITTEN_HEADERS = False
 
 @click.command()
 @click.option('--input', '-i', 'input_file', required=True, type=click.Path(exists=True),
@@ -138,10 +137,6 @@ def determine_best_hit(hits):
     return None
 
 def write_best_hit(outfile, query_id, best_hit):
-    #global WRITTEN_HEADERS
-    #if WRITTEN_HEADERS is False:
-    #    outfile.write("\t".join(OUTPUT_COLUMNS) + "\n")
-    #    WRITTEN_HEADERS = True
     best_hit['query_id'] = query_id
     outfile.write(
         "\t".join([str(best_hit[colname]) for colname in OUTPUT_COLUMNS]) + "\n"

--- a/foldseek/bin/format_fs_output.py
+++ b/foldseek/bin/format_fs_output.py
@@ -18,7 +18,7 @@ OUTPUT_COLUMNS = [
     'qcov',
     'tcov',
 ]
-WRITTEN_HEADERS = False
+# WRITTEN_HEADERS = False
 
 @click.command()
 @click.option('--input', '-i', 'input_file', required=True, type=click.Path(exists=True),
@@ -32,6 +32,7 @@ def process_foldseek(input_file, cath_domain_file, output_file):
     domain_lookup = parse_cath_domain_list(cath_domain_file)
 
     with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
+        outfile.write("\t".join(OUTPUT_COLUMNS) + "\n") # Added to always write headers
         current_query_hits = []
         current_query_id = None
 
@@ -137,10 +138,10 @@ def determine_best_hit(hits):
     return None
 
 def write_best_hit(outfile, query_id, best_hit):
-    global WRITTEN_HEADERS
-    if WRITTEN_HEADERS is False:
-        outfile.write("\t".join(OUTPUT_COLUMNS) + "\n")
-        WRITTEN_HEADERS = True
+    #global WRITTEN_HEADERS
+    #if WRITTEN_HEADERS is False:
+    #    outfile.write("\t".join(OUTPUT_COLUMNS) + "\n")
+    #    WRITTEN_HEADERS = True
     best_hit['query_id'] = query_id
     outfile.write(
         "\t".join([str(best_hit[colname]) for colname in OUTPUT_COLUMNS]) + "\n"

--- a/foldseek/modules/foldseek_process_results.nf
+++ b/foldseek/modules/foldseek_process_results.nf
@@ -14,8 +14,11 @@ process foldseek_process_results {
     script:
     """
     python3 ${parser_script} -i ${m8_file} -c ${lookup_file} -o foldseek_parsed_results.unsorted.tsv
-    
-    head -n 1 foldseek_parsed_results.unsorted.tsv > foldseek_parsed_results.tsv
-    tail -n +2 foldseek_parsed_results.unsorted.tsv | sort >> foldseek_parsed_results.tsv
+    if [ ! -s foldseek_parsed_results.unsorted.tsv ]; then
+        printf "query_id\ttarget_id\tevalue\ttmscore\tcode\ttype\tqcov\ttcov\nNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\n" > foldseek_parsed_results.tsv
+    else
+        head -n 1 foldseek_parsed_results.unsorted.tsv > foldseek_parsed_results.tsv
+        tail -n +2 foldseek_parsed_results.unsorted.tsv | sort >> foldseek_parsed_results.tsv
+    fi
     """
 }

--- a/foldseek/modules/foldseek_process_results.nf
+++ b/foldseek/modules/foldseek_process_results.nf
@@ -14,11 +14,7 @@ process foldseek_process_results {
     script:
     """
     python3 ${parser_script} -i ${m8_file} -c ${lookup_file} -o foldseek_parsed_results.unsorted.tsv
-    if [ ! -s foldseek_parsed_results.unsorted.tsv ]; then
-        printf "query_id\ttarget_id\tevalue\ttmscore\tcode\ttype\tqcov\ttcov\nNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\n" > foldseek_parsed_results.tsv
-    else
-        head -n 1 foldseek_parsed_results.unsorted.tsv > foldseek_parsed_results.tsv
-        tail -n +2 foldseek_parsed_results.unsorted.tsv | sort >> foldseek_parsed_results.tsv
-    fi
+    head -n 1 foldseek_parsed_results.unsorted.tsv > foldseek_parsed_results.tsv
+    tail -n +2 foldseek_parsed_results.unsorted.tsv | sort >> foldseek_parsed_results.tsv
     """
 }

--- a/modules/get_uniprot.nf
+++ b/modules/get_uniprot.nf
@@ -10,6 +10,17 @@ process get_uniprot_data {
 
     script:
     """
+    # If IDs look like MGnify ids (length > 10), skip the UniProt fetch as they won't exist and get_uniprot will fail.
+    first_id=\$(head -n 1 ${uniprot_id_file})
+
+    if [ \${#first_id} -gt 10 ]; then         
+        # Create a dummy file with the correct column headers
+        printf "accession\tproteome_id\ttax_common_name\ttax_scientific_name\ttax_lineage\n" > uniprot_data.tsv
+        # Then add blank taxonomy rows for all IDs
+        awk '{print \$1 "\t\t\t\t"}' ${uniprot_id_file} >> uniprot_data.tsv
+    else
+    # fetch the ids from Uniprot as usual
     ${params.fetch_uniprot_script} -i ${uniprot_id_file} -o uniprot_data.tsv
+    fi
     """
 }

--- a/modules/get_uniprot.nf
+++ b/modules/get_uniprot.nf
@@ -10,17 +10,6 @@ process get_uniprot_data {
 
     script:
     """
-    # If IDs look like MGnify ids (length > 10), skip the UniProt fetch as they won't exist and get_uniprot will fail.
-    first_id=\$(head -n 1 ${uniprot_id_file})
-
-    if [ \${#first_id} -gt 10 ]; then         
-        # Create a dummy file with the correct column headers
-        printf "accession\tproteome_id\ttax_common_name\ttax_scientific_name\ttax_lineage\n" > uniprot_data.tsv
-        # Then add blank taxonomy rows for all IDs
-        awk '{print \$1 "\t\t\t\t"}' ${uniprot_id_file} >> uniprot_data.tsv
-    else
-    # fetch the ids from Uniprot as usual
     ${params.fetch_uniprot_script} -i ${uniprot_id_file} -o uniprot_data.tsv
-    fi
     """
 }

--- a/workflows/annotate.nf
+++ b/workflows/annotate.nf
@@ -235,7 +235,7 @@ workflow {
         .map { it[1] }
         .toList()
         .flatMap { files ->                // Process the ordered list
-            files.collect { it.text }      // Read each file's content in order
+            files.collect { it.text.trim() }      // Read each file's content in order
         }
         .collectFile( 
             name: 'chunk_size_chunks.txt', // Note: this file contains the chunks from chunked_af_ids_ch. 


### PR DESCRIPTION
Changes log:
annotate.nf - Corrects a potential bug in which leads to duplication when chunk_size = 1. Adds trim() to remove extra line.
foldseek_process_results.nf - Creates a dummy output file should all ids result in 0 foldseek matches. Prevents downstream failure.
get_uniprot.nf - If IDs are not in Uniprot format, the process will create a dummy file to prevent downstream failure. This is required as  fetch_uniprot_data.py has the following clause which ignores ids not 6-10 alphanumeric:
UNIPROT_ACC_RE = re.compile(r'^[A-Z0-9]{6,10}$') 
if not clean:
    raise ValueError("No valid UniProt accessions after cleaning input").
Dockerfile - changes to safer GitHub option for STRIDE.
