### PR TITLE
Parse uniprot accession from start of filename  

### DIFF
--- a/docker/script/fetch_uniprot_data.py
+++ b/docker/script/fetch_uniprot_data.py
@@ -17,7 +17,7 @@ API_URL = "https://rest.uniprot.org"
 POLLING_INTERVAL = 3  # seconds
 
 # UniProt accession-ish regex (classic + extended)
-UNIPROT_ACC_RE = re.compile(r'^[A-Z0-9]{6,10}$')
+UNIPROT_ACC_RE = re.compile(r'^[A-NR-Z][0-9][A-Z0-9]{3}[0-9]|^[OPQ][0-9][A-Z0-9]{3}[0-9]|^[A-Z0-9]{1,2}[0-9][A-Z0-9]{2}[0-9]{3}')
 
 # Session with retries on transient errors
 session = requests.Session()
@@ -393,16 +393,13 @@ if __name__ == "__main__":
     parser.add_argument('--batch-size', type=int, default=1000, help='Batch size for UniProt queries (default: 1000)')
     args = parser.parse_args()
 
-    import re
-    uniprot_pattern = re.compile(r'^[A-NR-Z][0-9][A-Z0-9]{3}[0-9]$|^[OPQ][0-9][A-Z0-9]{3}[0-9]$|^[A-Z0-9]{1,2}[0-9][A-Z0-9]{2}[0-9]{3}$')
-
     if args.input:
         with open(args.input) as f:
             accessions = [line.strip() for line in f if line.strip()]
     elif args.accession:
         accessions = [a.strip() for a in args.accession.split(',') if a.strip()]
         # Validate each accession
-        invalid = [a for a in accessions if not uniprot_pattern.match(a)]
+        invalid = [a for a in accessions if not UNIPROT_ACC_RE.match(a)]
         if invalid:
             print(f"Error: The following accessions are not valid UniProt accessions: {', '.join(invalid)}")
             exit(1)

--- a/docker/script/fetch_uniprot_data.py
+++ b/docker/script/fetch_uniprot_data.py
@@ -36,20 +36,25 @@ def normalise_afdb_id(s: str) -> str:
         return m.group(1)
     return s
 
-def clean_accessions(accessions):
+def clean_accessions(original_ids):
     """Strip whitespace, drop obvious headers/garbage, keep only valid-looking accessions."""
     clean = []
-    for a in accessions:
-        a = normalise_afdb_id(a) # a = a.strip()
-        if not a:
+    for orig_id in original_ids:
+        orig_id = normalise_afdb_id(orig_id) # a = a.strip()
+        if not orig_id:
             continue
-        if a.lower() in {"uniprot_id", "accession", "id"}:
+        if orig_id.lower() in {"uniprot_id", "accession", "id"}:
             continue
-        if not UNIPROT_ACC_RE.match(a):
+
+        id_match = UNIPROT_ACC_RE.match(orig_id)
+
+        if id_match:
+            clean_id = id_match.group(0)
+            clean.append(clean_id)
+        else:
             # Debug only if you like:
-            print(f"[WARN] Skipping invalid accession candidate: {a!r}")
+            print(f"[WARN] Skipping invalid accession candidate: {orig_id!r}")
             continue
-        clean.append(a)
 
     return clean
 
@@ -398,12 +403,9 @@ if __name__ == "__main__":
             accessions = [line.strip() for line in f if line.strip()]
     elif args.accession:
         accessions = [a.strip() for a in args.accession.split(',') if a.strip()]
-        # Validate each accession
-        invalid = [a for a in accessions if not UNIPROT_ACC_RE.match(a)]
-        if invalid:
-            print(f"Error: The following accessions are not valid UniProt accessions: {', '.join(invalid)}")
-            exit(1)
     else:
         accessions = []
+
+    accessions = clean_accessions(accessions)
 
     run(accessions, args.output, batch_size=args.batch_size)

--- a/docker/script/fetch_uniprot_data.py
+++ b/docker/script/fetch_uniprot_data.py
@@ -408,4 +408,8 @@ if __name__ == "__main__":
 
     accessions = clean_accessions(accessions)
 
+    if not accessions:
+        print("[ERROR] No valid UniProt accessions provided.")
+        exit(1)
+
     run(accessions, args.output, batch_size=args.batch_size)


### PR DESCRIPTION
Allows uniprot id to be parsed from the start of the filename (rather than expecting the filename to exactly match a uniprot accession):

- currently the script has two regexps to parse / validate uniprot accessions within the filename
- this change just uses one (prefers the more specific regexp) 
- checks for the accession at the start of the string, but allows more characters to follow