### PR TITLE
Use ghrc url for containers (in modules, not config files)

### DIFF
--- a/conf/container.config
+++ b/conf/container.config
@@ -51,5 +51,8 @@ params {
 }
 
 process {
-    container = "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
+    // Only set a default container for processes that do not declare one inline
+    withName: 'collect_results|collect_taxonomy|join_plddt_md5|collect_chopping_names|fetch_foldseek_assets|foldseek_filter_domain_agreement|files_from_zip' {
+        container = "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
+    }
 }

--- a/conf/container.config
+++ b/conf/container.config
@@ -1,3 +1,4 @@
+
 params {
     unidoc_dir = "/app/UniDoc"
     fetch_uniprot_script = "python3 /app/fetch_uniprot_data.py"
@@ -47,4 +48,8 @@ params {
     . ted_consensus/bin/activate
     """
     run_segmentation_script = "bash run_segmentation.sh"
+}
+
+process {
+    container = "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
 }

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -1,68 +1,13 @@
 docker {
     enabled = true
-    runOptions = "-v ${launchDir}:/launchDir:ro"
+    runOptions = "--platform linux/amd64 -v ${launchDir}:/launchDir:ro"
 }
 
 process {
 
-    withName: '.*' {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-script:main-latest' // Use GHCR image
-        container = "domain-annotation-pipeline-script"
-    }
-
-    withName: chop_pdb_from_zip {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-script:main-latest' // Use GHCR image
-        container = 'domain-annotation-pipeline-script'
-        memory = '8 GB'
-    }
-
-    withName: collect_results {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-script:main-latest' // Use GHCR image
-        container = 'domain-annotation-pipeline-script'
-    }
-
-    withName: run_stride {
-        container = 'domain-annotation-pipeline-cath-af-cli'
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:main-latest' // Use GHCR image
-    }
-
-    withName: create_md5 {
-        container = 'domain-annotation-pipeline-cath-af-cli'
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:main-latest' // Use GHCR image
-    }
-
-    withName: run_measure_globularity {
-        container = 'domain-annotation-pipeline-cath-af-cli'
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:main-latest' // Use GHCR image
-    }
-
     withName: run_ted_segmentation {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:main-latest' // Use GHCR image
-        container = 'domain-annotation-pipeline-ted-tools'
         memory = { params.project_name == 'git_actions_test' ? '14 GB' : '16 GB' }
         cpus = 2
     }
 
-    // ===== Domain quality (from main) =====
-    withName: run_domain_quality {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:main-latest' // Use GHCR image
-        container = 'domain-annotation-pipeline-ted-tools'
-    }
-
-    // ===== Foldseek (from run_foldseek) =====
-    // Use the Steinegger GH container. Note: entrypoint disabled
-    // foldseek_exec = 'foldseek_arch' (docker)
-    // params.foldseek_exec = '/usr/local/bin/foldseek_avx2' (singularity)
-    withName: 'foldseek_create_db|foldseek_run_foldseek|foldseek_run_convertalis' {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-foldseek:main-latest' // Use GHCR image
-        container = 'domain-annotation-pipeline-foldseek:latest'
-        memory = { params.project_name == 'git_actions_test' ? '14 GB' : '16 GB' }
-        containerOptions = '--entrypoint ""' 
-    }
-
-    // Let the bespoke parser script run in the script container
-    withName: 'foldseek_process_results' {
-        //container = 'ghcr.io/uclorengogroup/domain-annotation-pipeline-script:main-latest' // Use GHCR image
-        container = 'domain-annotation-pipeline-script'
-    }
 }

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -12,6 +12,5 @@ process {
 
     withName: 'foldseek_create_db|foldseek_run_foldseek|foldseek_run_convertalis' {
         memory = { params.project_name == 'git_actions_test' ? 14.GB : 16.GB }
-        containerOptions = '--entrypoint ""'
     }
 }

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -6,8 +6,12 @@ docker {
 process {
 
     withName: run_ted_segmentation {
-        memory = { params.project_name == 'git_actions_test' ? '14 GB' : '16 GB' }
+        memory = { params.project_name == 'git_actions_test' ? 14.GB : 16.GB }
         cpus = 2
     }
 
+    withName: 'foldseek_create_db|foldseek_run_foldseek|foldseek_run_convertalis' {
+        memory = { params.project_name == 'git_actions_test' ? 14.GB : 16.GB }
+        containerOptions = '--entrypoint ""'
+    }
 }

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -1,7 +1,7 @@
 params.singularity_image_dir = '/SAN/orengolab/bfvd/singularity_images'
 //params.scratch_dir = "/SAN/orengolab/bfvd/nextflow_scratch/${System.getenv('USER')}"
 //params.scratch_dir = true
-params.scratch_dir = "/state/partition1/scratch0/${System.getenv('USER')}"
+params.scratch_dir = "/state/partition1/scratch0"
 params.project = params.project ?: 'cath'
 
 // Exclude specific nodes from GPU jobs
@@ -47,9 +47,9 @@ process {
 
         // Common SGE options for non-GPU jobs
         clusterOptions = {
-            def mem  = task.memory ? task.memory.mega : '2000'
+            def mem  = task.memory ? task.memory.toMega() : 2000
             def cpus = task.cpus
-            def scratchSpace = task.ext.scratchSpace ? task.ext.scratchSpace.mega : '1000'
+            def scratchSpace = task.ext.scratchSpace ?: '1000'
             def time = task.time ? task.time.toString() : '23h'
             def opts = "-P ${params.project} -S /bin/bash -l tmem=${mem}M,h_vmem=${mem}M,h_rt=${time.replace('h', ':00:00')},tscratch=${scratchSpace}M,scratch0free=${scratchSpace}M"
             // AVX2-only for foldseek processes
@@ -70,9 +70,9 @@ process {
 
         // Common SGE options for GPU jobs: use task.memory, add gpu + h_rt
         clusterOptions = {
-            def mem  = task.memory ? task.memory.mega : '16000'
+            def mem  = task.memory ? task.memory.toMega() : 16000
             def cpus = task.cpus
-            def scratchSpace = task.ext.scratchSpace ? task.ext.scratchSpace.mega : '1000'
+            def scratchSpace = task.ext.scratchSpace ?: '1000'
             def time = task.time ? task.time.toString() : '23h'
             def opts = "-P ${params.project} -S /bin/bash -l tmem=${mem}M,h_vmem=${mem}M -l gpu=true -l h_rt=${time.replace('h', ':00:00')},tscratch=${scratchSpace}M,scratch0free=${scratchSpace}M"
             
@@ -114,11 +114,10 @@ process {
     withName: chop_pdb_from_zip {
         errorStrategy = 'retry'
         maxRetries    = 3
-        memory        = { task.attempt == 1 ? 1.GB : task.attempt == 2 ? 2.GB : 8.GB }
+        memory        = { task.attempt == 1 ? 2.GB : task.attempt == 2 ? 4.GB : 8.GB }
     }
 
     withName: collect_results {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 4.GB : task.attempt == 2 ? 8.GB : 12.GB }
@@ -132,8 +131,9 @@ process {
     }
 
     withName: normalise_af_ids {
-        executor = 'local'
+        executor  = 'local'
         container = null
+        scratch   = false
     }
 
     withName: 'download_bcif_from_afdb' {
@@ -152,12 +152,14 @@ process {
 
     withName: transform_consensus {
         executor      = 'local'
+        scratch       = false
     }
 
     withName: filter_pdb_from_zip {
         executor      = 'local'
         errorStrategy = 'retry'
         maxRetries    = 3
+        scratch       = false
     }
 
     // ---------- TED-TOOLS ------------
@@ -165,14 +167,14 @@ process {
         errorStrategy = 'retry'
         maxRetries    = 4
         // 1st attempt: 31 GB, 2nd: 45 GB, 3rd: 63 GB.
-        memory        = { task.attempt == 1 ? 31.GB : task.attempt == 2 ? 45.GB : 63.GB }
+        memory        = { task.attempt == 1 ? 32.GB : task.attempt == 2 ? 48.GB : 63.GB }
         time          = '23h'    // used for documentation; h_rt fixed in label as before
     }
 
     withName: run_domain_quality {
         errorStrategy = 'retry'
         maxRetries    = 3
-        memory        = { task.attempt == 1 ? 15.GB : task.attempt == 2 ? 23.GB : 31.GB }
+        memory        = { task.attempt == 1 ? 31.GB : task.attempt == 2 ? 45.GB : 63.GB }
     }
 
     // ---------- CATH-AF-CLI ------------
@@ -189,6 +191,11 @@ process {
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 2.GB : task.attempt == 2 ? 4.GB : 8.GB }
         time          = '12h'
+    }
+
+    withName: create_md5 {
+        executor      = 'local'
+        scratch       = false
     }
 }
 

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -15,7 +15,6 @@ executor {
 process {
 
     cache = 'lenient'
-    container = "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
     stageInMode = 'copy'
     stageOutMode = 'copy'
 
@@ -91,7 +90,6 @@ process {
     // ---------- DEFAULT CONTAINERS ----------
 
     withName: 'foldseek_create_db|foldseek_run_convertalis' {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-foldseek_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 4.GB : task.attempt == 2 ? 15.GB : 25.GB }
@@ -101,7 +99,6 @@ process {
     // ---------- PROCESS-SPECIFIC OVERRIDES ----------
     // ---------- SCRIPT/DEFAULT ------------
     withName: foldseek_run_foldseek {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-foldseek_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 15.GB : task.attempt == 2 ? 31.GB : 45.GB }
@@ -109,14 +106,12 @@ process {
     }
 
     withName: foldseek_process_results {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 1.GB : task.attempt == 2 ? 2.GB : 8.GB }
     }
 
     withName: chop_pdb_from_zip {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 1.GB : task.attempt == 2 ? 2.GB : 8.GB }
@@ -142,7 +137,6 @@ process {
     }
 
     withName: 'download_bcif_from_afdb' {
-        container        = "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
         time             = '23h'
         memory           = 7.GB
         maxForks         = 50
@@ -150,7 +144,6 @@ process {
     }
 
     withName: 'prepare_pdb_from_af_bcif' {
-        container        = "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
         time             = '23h'
         memory           = { task.attempt == 1 ? 23.GB : 31.GB }
         ext.scratchSpace = 20.GB
@@ -169,7 +162,6 @@ process {
 
     // ---------- TED-TOOLS ------------
     withName: run_ted_segmentation {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-ted-tools_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 4
         // 1st attempt: 31 GB, 2nd: 45 GB, 3rd: 63 GB.
@@ -178,7 +170,6 @@ process {
     }
 
     withName: run_domain_quality {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-ted-tools_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 15.GB : task.attempt == 2 ? 23.GB : 31.GB }
@@ -186,7 +177,6 @@ process {
 
     // ---------- CATH-AF-CLI ------------
     withName: run_stride {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-cath-af-cli_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 1.GB : task.attempt == 2 ? 2.GB : 8.GB }
@@ -194,12 +184,7 @@ process {
         
     }
 
-    withName: create_md5 {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-cath-af-cli_latest.sif"
-    }
-
     withName: run_measure_globularity {
-        container     = "${params.singularity_image_dir}/domain-annotation-pipeline-cath-af-cli_latest.sif"
         errorStrategy = 'retry'
         maxRetries    = 3
         memory        = { task.attempt == 1 ? 2.GB : task.attempt == 2 ? 4.GB : 8.GB }

--- a/foldseek/modules/foldseek_create_db.nf
+++ b/foldseek/modules/foldseek_create_db.nf
@@ -1,7 +1,7 @@
 process foldseek_create_db {
     label 'sge_low'
-    container 'domain-annotation-pipeline-foldseek'
-    
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-foldseek:${params.container_tag_name}" 
+
     input:
     tuple val(id), path(chopped_pdb_tar_file)
 

--- a/foldseek/modules/foldseek_process_results.nf
+++ b/foldseek/modules/foldseek_process_results.nf
@@ -1,6 +1,7 @@
 process foldseek_process_results {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script' 
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
+    
     //publishDir "${params.results_dir}" , mode: 'copy' // unnecessary as it is already covered in collectFile 
 
     input:

--- a/foldseek/modules/foldseek_run_convertalis.nf
+++ b/foldseek/modules/foldseek_run_convertalis.nf
@@ -1,6 +1,6 @@
 process foldseek_run_convertalis {
     label 'sge_low'
-    container 'domain-annotation-pipeline-foldseek'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-foldseek:${params.container_tag_name}" 
     publishDir "results/convertalis", mode: 'copy', enabled: params.debug
     
     input:

--- a/foldseek/modules/foldseek_run_foldseek.nf
+++ b/foldseek/modules/foldseek_run_foldseek.nf
@@ -1,6 +1,6 @@
 process foldseek_run_foldseek {
     label 'sge_low'
-    container 'domain-annotation-pipeline-foldseek'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-foldseek:${params.container_tag_name}" 
     
     input:
     tuple val(id), path(query_db_dir)

--- a/modules/chop_pdb.nf
+++ b/modules/chop_pdb.nf
@@ -1,6 +1,6 @@
 process chop_pdb {
     label 'sge_low'
-    container 'domain-annotation-pipeline-pdb-tools' 
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}" , mode: 'copy'
 
     input:

--- a/modules/chop_pdb_from_zip.nf
+++ b/modules/chop_pdb_from_zip.nf
@@ -1,6 +1,6 @@
 process chop_pdb_from_zip {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script' 
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}/chopped_pdbs" , mode: 'copy'
 
     input:

--- a/modules/chop_pdb_from_zip.nf
+++ b/modules/chop_pdb_from_zip.nf
@@ -1,6 +1,7 @@
 process chop_pdb_from_zip {
     label 'sge_low'
     container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
+    memory 8.GB
     publishDir "${params.results_dir}/chopped_pdbs" , mode: 'copy'
 
     input:

--- a/modules/chunk_by_zipfile.nf
+++ b/modules/chunk_by_zipfile.nf
@@ -1,6 +1,6 @@
 process chunk_ids_by_zip {
     label 'sge_low'
-    container "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}/intermediate", mode: 'copy', enabled: params.debug
 
     input:

--- a/modules/collect_results_add_metadata.nf
+++ b/modules/collect_results_add_metadata.nf
@@ -1,6 +1,6 @@
 process collect_results_final {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}" , mode: 'copy'
 
     input:

--- a/modules/convert_merizo_results.nf
+++ b/modules/convert_merizo_results.nf
@@ -1,6 +1,6 @@
 process convert_merizo_results {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
 
     input:
     file 'chainsaw_results.tsv'

--- a/modules/convert_unidoc_results.nf
+++ b/modules/convert_unidoc_results.nf
@@ -1,6 +1,6 @@
 process convert_unidoc_results {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
 
     input:
     file 'chainsaw_results.tsv'

--- a/modules/create_domain_md5.nf
+++ b/modules/create_domain_md5.nf
@@ -1,6 +1,6 @@
 process create_md5 {
     label 'sge_low'
-    container 'domain-annotation-pipeline-cath-af-cli'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:${params.container_tag_name}" 
 
     input:
     tuple val(id), path(chopped_pdb_tar_file)

--- a/modules/create_input_from_zip.nf
+++ b/modules/create_input_from_zip.nf
@@ -1,6 +1,6 @@
 process create_input_from_zip {
     label 'sge_low'
-    container "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}/intermediate", mode: 'copy' //, enabled: params.debug // only publish if run in debug mode
     
     input:

--- a/modules/extract_pdb_from_tar.nf
+++ b/modules/extract_pdb_from_tar.nf
@@ -1,6 +1,6 @@
 process extract_pdb_from_tar {
     label 'sge_gpu_high'
-    container 'domain-annotation-pipeline-pdb-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir './results/pdbs', mode: 'copy'
 
     input:

--- a/modules/extract_pdb_from_zip.nf
+++ b/modules/extract_pdb_from_zip.nf
@@ -1,6 +1,6 @@
 process extract_pdb_from_zip {
     label 'sge_low'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}" 
 
     input:
     tuple( val(id), path(id_file) )

--- a/modules/filter_pdb_from_zip.nf
+++ b/modules/filter_pdb_from_zip.nf
@@ -1,7 +1,7 @@
 // filter pdb files to only include those with > 25 residues. 10-Feb-26 added sort statement to for loop.
 process filter_pdb_from_zip {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
 
     input:
     tuple(val(chunk_id), path(id_file), path(pdb_zip))

--- a/modules/get_uniprot.nf
+++ b/modules/get_uniprot.nf
@@ -1,6 +1,6 @@
 process get_uniprot_data {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
 
     input:
     tuple(val(id), path(id_file))

--- a/modules/light_chunk_consensus_by_zipfile.nf
+++ b/modules/light_chunk_consensus_by_zipfile.nf
@@ -1,6 +1,6 @@
 process light_chunk_consensus_by_zip {
     label 'sge_low'
-    container "${params.singularity_image_dir}/domain-annotation-pipeline-script_latest.sif"
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}/intermediate", mode: 'copy', enabled: params.debug // only publish if run in debug mode
     
     input:

--- a/modules/prepare_af_pdb_zip.nf
+++ b/modules/prepare_af_pdb_zip.nf
@@ -11,21 +11,23 @@ nextflow.enable.dsl = 2
 process download_bcif_from_afdb {
     label 'sge_low'
     tag "$chunk_id"
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
+
     publishDir "${params.results_dir}/prepared/chunks", mode: (params.publish_mode ?: 'copy')
 
     input:
     tuple val(chunk_id), path(afdb_ids_file)
-  path download_script
+    path download_script
     val base_url
 
     output:
     tuple(
-    val(chunk_id),
-    path("${chunk_id}.bcif_files.zip"),
-    path("${chunk_id}.downloaded_ids.txt"),
-    path("${chunk_id}.failed_ids.txt"),
-    path("${chunk_id}.prep_summary.txt"),
-    path("${chunk_id}.download_log.tsv")
+      val(chunk_id),
+      path("${chunk_id}.bcif_files.zip"),
+      path("${chunk_id}.downloaded_ids.txt"),
+      path("${chunk_id}.failed_ids.txt"),
+      path("${chunk_id}.prep_summary.txt"),
+      path("${chunk_id}.download_log.tsv")
     )
 
     script:
@@ -55,6 +57,8 @@ process download_bcif_from_afdb {
 
 process normalise_af_ids {
     label 'sge_low'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
+
     publishDir "${params.results_dir}/prepared", mode: (params.publish_mode ?: 'copy')
 
     input:
@@ -72,6 +76,8 @@ process normalise_af_ids {
 process ids_from_bcif_zip {
     label 'sge_low'
     tag "$chunk_id"
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
+
     publishDir "${params.results_dir}/prepared/chunks", mode: (params.publish_mode ?: 'copy')
 
     input:
@@ -93,6 +99,8 @@ process ids_from_bcif_zip {
 
 process prepare_pdb_from_af_bcif {
     label 'sge_low'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
+
     tag "$chunk_id"
     publishDir "${params.results_dir}/prepared/chunks", mode: (params.publish_mode ?: 'copy')
 

--- a/modules/prepare_pdb_file.nf
+++ b/modules/prepare_pdb_file.nf
@@ -1,6 +1,6 @@
 process prepare_pdb_file {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}" 
     publishDir "${params.results_dir}" , mode: 'copy', enabled: params.debug // only publish if run in debug mode
 
     input:

--- a/modules/run_chainsaw.nf
+++ b/modules/run_chainsaw.nf
@@ -1,6 +1,6 @@
 process run_chainsaw {
     label 'sge_gpu_high'
-    container 'domain-annotation-pipeline-chainsaw'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}" 
 
     input:
     path '*'

--- a/modules/run_create_AF_domain_id.nf
+++ b/modules/run_create_AF_domain_id.nf
@@ -1,6 +1,7 @@
 process run_AF_domain_id {
     label 'sge_low'
-    container 'domain-annotation-pipeline-cath-af-cli'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:${params.container_tag_name}"
+    
     publishDir "${params.results_dir}", mode: 'copy'
 
     input:

--- a/modules/run_domain_quality.nf
+++ b/modules/run_domain_quality.nf
@@ -1,6 +1,6 @@
 process run_domain_quality {
     label 'sge_gpu_high'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}" 
 
     input:
     tuple val(id), path(chopped_pdb_tar_file)

--- a/modules/run_domain_quality_from_zip.nf
+++ b/modules/run_domain_quality_from_zip.nf
@@ -1,6 +1,6 @@
 process run_domain_quality_from_zip {
     label 'sge_gpu_high'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}" 
 
     input:
     tuple val(id), path(pdb_list)

--- a/modules/run_filter_consensus.nf
+++ b/modules/run_filter_consensus.nf
@@ -4,7 +4,7 @@
  */
 process run_filter_consensus {
     label 'sge_low'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy'
 
     input:

--- a/modules/run_filter_domains.nf
+++ b/modules/run_filter_domains.nf
@@ -5,7 +5,7 @@
  */
 process run_filter_domains {
     label 'sge_low'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy'
 
     input:

--- a/modules/run_filter_domains_reformatted.nf
+++ b/modules/run_filter_domains_reformatted.nf
@@ -5,7 +5,7 @@
  */
 process run_filter_domains_reformatted {
     label 'sge_low'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy'
 
     input:

--- a/modules/run_get_consensus.nf
+++ b/modules/run_get_consensus.nf
@@ -4,7 +4,7 @@
  */
 process run_get_consensus {
     label 'sge_low'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy'
     
     input:

--- a/modules/run_measure_globularity.nf
+++ b/modules/run_measure_globularity.nf
@@ -1,6 +1,6 @@
 process run_measure_globularity {
     label 'sge_low'
-    container 'domain-annotation-pipeline-cath-af-cli'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy', enabled: params.debug
 
     input:

--- a/modules/run_merizo.nf
+++ b/modules/run_merizo.nf
@@ -1,6 +1,6 @@
 process run_merizo {
     label 'sge_gpu_high'
-    container 'domain-annotation-pipeline-merizo'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
 
     input:
     path '*'

--- a/modules/run_plddt.nf
+++ b/modules/run_plddt.nf
@@ -1,6 +1,6 @@
 process run_plddt {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy', enabled: params.debug
 
     input:

--- a/modules/run_stride.nf
+++ b/modules/run_stride.nf
@@ -1,6 +1,6 @@
 process run_stride {
     label 'sge_low'
-    container 'domain-annotation-pipeline-cath-af-cli'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-cath-af-cli:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy', enabled: params.debug // only publish if run in debug mode
 
     input:

--- a/modules/run_ted_segmentation.nf
+++ b/modules/run_ted_segmentation.nf
@@ -1,6 +1,6 @@
 process run_ted_segmentation {
     label 'sge_gpu_high'
-    container 'domain-annotation-pipeline-ted-tools'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
 
     input:
     tuple(val(chunk_id), path(filtered_id_file), path(pdb_zip))

--- a/modules/run_unidoc.nf
+++ b/modules/run_unidoc.nf
@@ -1,6 +1,6 @@
 process run_unidoc {
     label 'sge_low'
-    container 'domain-annotation-pipeline-unidoc'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-ted-tools:${params.container_tag_name}"
 
     input:
     path '*'

--- a/modules/summarise_stride.nf
+++ b/modules/summarise_stride.nf
@@ -1,6 +1,6 @@
 process summarise_stride {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy', enabled: params.debug // only publish if run in debug mode
 
     input:

--- a/modules/transform.nf
+++ b/modules/transform.nf
@@ -1,6 +1,6 @@
 process transform_consensus {
     label 'sge_low'
-    container 'domain-annotation-pipeline-script'
+    container "ghcr.io/uclorengogroup/domain-annotation-pipeline-script:${params.container_tag_name}"
     publishDir "${params.results_dir}" , mode: 'copy'
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,8 @@ params {
     debug = false
     ci_mode = false 
     publish_mode = 'copy'
+
+    container_tag_name = 'main-latest'
     // cif_mode = false // this function is disabled for multizip processing.
 
     unidoc_dir = "${baseDir}/tools/UniDoc"


### PR DESCRIPTION
- use ghrc url for containers (avoid docker versus singularity)
- inline container params inside module / process
- remove container params from config files
- allows "tag" for versioned images (default: `main-latest`)
- allow nextflow to manage pulling docker/singularity images from ghrc 