### PR TITLE
Includes updates to resolve runtime errors on CS-cluster

### DIFF
--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -85,6 +85,11 @@ process {
         maxRetries    = 3
         scratch       = false
     }
+    // These should locally to prevent output files used by downstream processes becoming lost in the NODE scratch directory 
+    withName: 'create_input_from_zip|chunk_by_zip|heavy_chunk_by_zip|light_chunk_consensus_by_zip|run_plddt|join_plddt_md5|benchmark_compare_results' {
+        executor      = 'local'
+        scratch       = false
+    }
 
     // ---------- TED-TOOLS ------------
     withName: 'run_ted_merizo_unidoc|run_ted_chainsaw' {

--- a/modules/benchmark_compare_results.nf
+++ b/modules/benchmark_compare_results.nf
@@ -14,6 +14,10 @@ process benchmark_compare_results {
     """
     sort ${final_results} > final_results.sorted.tsv
     sort ${expected_results} > expected.sorted.tsv
-    diff -u final_results.sorted.tsv expected.sorted.tsv > benchmark_differences.tsv
+    
+    diff -u final_results.sorted.tsv expected.sorted.tsv > benchmark_differences.tsv || {
+        status=\$?
+        [ "\$status" -eq 1 ] || exit "\$status"
+    }
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,25 +78,25 @@ params {
     lookup_file = "${params.cache_dir}/CathDomainList.S95.v4.4.0"
 
     no_gpu = false // Don't use gpus on Myriad
-    results_dir = null // Added to initialise results_dir or will get Unknown config attribute error
+    params.results_dir = params.results_dir ?: "${launchDir}/reports" // makes sure a fall back is supplied in case the user doesn't supply one.
 }
 
 // Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
-    file    = "${params.results_dir ?: "${launchDir}/reports"}/execution_timeline_${params.trace_timestamp}.html"
+    file    = "${params.results_dir}/execution_timeline_${params.trace_timestamp}.html"
 }
 report {
     enabled = true
-    file    = "${params.results_dir ?: "${launchDir}/reports"}/execution_report_${params.trace_timestamp}.html"
+    file    = "${params.results_dir}/execution_report_${params.trace_timestamp}.html"
 }
 trace {
     enabled = true
-    file    = "${params.results_dir ?: "${launchDir}/reports"}/execution_trace_${params.trace_timestamp}.txt"
+    file    = "${params.results_dir}/execution_trace_${params.trace_timestamp}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.results_dir ?: "${launchDir}/reports"}/pipeline_dag_${params.trace_timestamp}.html"
+    file    = "${params.results_dir}/pipeline_dag_${params.trace_timestamp}.html"
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,7 +82,7 @@ params {
     params.results_dir = params.results_dir ?: "${launchDir}/results/${params.project_name}"
 }
 
-// Hardcoded reports/ folder (or --resultss_dir if set), timestamped per launch so runs never overwrite.
+// Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
     file    = "${params.results_dir}/execution_timeline_${params.trace_timestamp}.html"

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,6 +78,7 @@ params {
     lookup_file = "${params.cache_dir}/CathDomainList.S95.v4.4.0"
 
     no_gpu = false // Don't use gpus on Myriad
+    results_dir = null // Added to initialise results_dir or will get Unknown config attribute error
 }
 
 // Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,27 +78,26 @@ params {
     lookup_file = "${params.cache_dir}/CathDomainList.S95.v4.4.0"
 
     no_gpu = false // Don't use gpus on Myriad
-    // Default output locations. CLI params can still override these values.
-    results_dir = "${launchDir}/results/${params.project_name}"
-    reports_dir = "${launchDir}/reports"
+    // makes sure a fall back is supplied in case the user doesn't supply one - set to the same as it is in annotate.nf.
+    reports_dir = params.reports_dir ?: "${launchDir}/reports"
 }
 
 // Hardcoded reports/ folder (or --reports_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
-    file    = "${params.reports_dir}/execution_timeline-${params.project_name}-${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/execution_timeline_${params.trace_timestamp}.html"
 }
 report {
     enabled = true
-    file    = "${params.reports_dir}/execution_report-${params.project_name}-${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/execution_report_${params.trace_timestamp}.html"
 }
 trace {
     enabled = true
-    file    = "${params.reports_dir}/execution_trace-${params.project_name}-${params.trace_timestamp}.txt"
+    file    = "${params.reports_dir}/execution_trace_${params.trace_timestamp}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.reports_dir}/pipeline_dag-${params.project_name}-${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/pipeline_dag_${params.trace_timestamp}.html"
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,10 +78,11 @@ params {
     lookup_file = "${params.cache_dir}/CathDomainList.S95.v4.4.0"
 
     no_gpu = false // Don't use gpus on Myriad
-    params.results_dir = params.results_dir ?: "${launchDir}/reports" // makes sure a fall back is supplied in case the user doesn't supply one.
+    // makes sure a fall back is supplied in case the user doesn't supply one - set to the same as it is in annotate.nf.
+    params.results_dir = params.results_dir ?: "${launchDir}/results/${params.project_name}"
 }
 
-// Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.
+// Hardcoded reports/ folder (or --reports_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
     file    = "${params.results_dir}/execution_timeline_${params.trace_timestamp}.html"

--- a/nextflow.config
+++ b/nextflow.config
@@ -80,24 +80,25 @@ params {
     no_gpu = false // Don't use gpus on Myriad
     // makes sure a fall back is supplied in case the user doesn't supply one - set to the same as it is in annotate.nf.
     params.results_dir = params.results_dir ?: "${launchDir}/results/${params.project_name}"
+    params.reports_dir = params.reports_dir ?: "${launchDir}/reports/${params.project_name}"
 }
 
 // Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
-    file    = "${params.results_dir}/execution_timeline_${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/execution_timeline_${params.trace_timestamp}.html"
 }
 report {
     enabled = true
-    file    = "${params.results_dir}/execution_report_${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/execution_report_${params.trace_timestamp}.html"
 }
 trace {
     enabled = true
-    file    = "${params.results_dir}/execution_trace_${params.trace_timestamp}.txt"
+    file    = "${params.reports_dir}/execution_trace_${params.trace_timestamp}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.results_dir}/pipeline_dag_${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/pipeline_dag_${params.trace_timestamp}.html"
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,7 +82,7 @@ params {
     params.results_dir = params.results_dir ?: "${launchDir}/results/${params.project_name}"
 }
 
-// Hardcoded reports/ folder (or --reports_dir if set), timestamped per launch so runs never overwrite.
+// Hardcoded reports/ folder (or --resultss_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
     file    = "${params.results_dir}/execution_timeline_${params.trace_timestamp}.html"

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,9 +78,9 @@ params {
     lookup_file = "${params.cache_dir}/CathDomainList.S95.v4.4.0"
 
     no_gpu = false // Don't use gpus on Myriad
-    // makes sure a fall back is supplied in case the user doesn't supply one - set to the same as it is in annotate.nf.
-    params.results_dir = params.results_dir ?: "${launchDir}/results/${params.project_name}"
-    params.reports_dir = params.reports_dir ?: "${launchDir}/reports/${params.project_name}"
+    // Default output locations. CLI params can still override these values.
+    results_dir = "${launchDir}/results/${params.project_name}"
+    reports_dir = "${launchDir}/reports/${params.project_name}"
 }
 
 // Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.

--- a/nextflow.config
+++ b/nextflow.config
@@ -80,25 +80,25 @@ params {
     no_gpu = false // Don't use gpus on Myriad
     // Default output locations. CLI params can still override these values.
     results_dir = "${launchDir}/results/${params.project_name}"
-    reports_dir = "${launchDir}/reports/${params.project_name}"
+    reports_dir = "${launchDir}/reports"
 }
 
-// Hardcoded reports/ folder (or --results_dir if set), timestamped per launch so runs never overwrite.
+// Hardcoded reports/ folder (or --reports_dir if set), timestamped per launch so runs never overwrite.
 timeline {
     enabled = true
-    file    = "${params.reports_dir}/execution_timeline_${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/execution_timeline-${params.project_name}-${params.trace_timestamp}.html"
 }
 report {
     enabled = true
-    file    = "${params.reports_dir}/execution_report_${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/execution_report-${params.project_name}-${params.trace_timestamp}.html"
 }
 trace {
     enabled = true
-    file    = "${params.reports_dir}/execution_trace_${params.trace_timestamp}.txt"
+    file    = "${params.reports_dir}/execution_trace-${params.project_name}-${params.trace_timestamp}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.reports_dir}/pipeline_dag_${params.trace_timestamp}.html"
+    file    = "${params.reports_dir}/pipeline_dag-${params.project_name}-${params.trace_timestamp}.html"
 }
 
 profiles {

--- a/workflows/annotate.nf
+++ b/workflows/annotate.nf
@@ -15,6 +15,8 @@ nextflow.enable.dsl = 2
 // ===============================================
 // Output directory
 params.publish_mode = 'copy'
+params.results_dir = params.results_dir ?: "${workflow.launchDir}/results/${params.project_name ?: 'undefined_project'}"
+params.reports_dir = params.reports_dir ?: "${workflow.launchDir}/reports/${params.project_name ?: 'undefined_project'}"
 
 // ===============================================
 // MODULE IMPORTS
@@ -136,6 +138,10 @@ def validateParameters() {
     if (!file(params.results_dir).exists()) {
         file(params.results_dir).mkdirs()
     }
+    // Ensure reports directory exists
+    if (!file(params.reports_dir).exists()) {
+        file(params.reports_dir).mkdirs()
+    }
 
     // Validate required parameters
     if (!params.input_zip_dir || !file(params.input_zip_dir).exists()) {
@@ -200,10 +206,6 @@ workflow {
     
     validateParameters()
     
-    // make sure results and reports directories exist
-    file(params.results_dir).mkdirs()
-    file(params.reports_dir).mkdirs()
-
     // =========================================
     // PHASE 0: Setup Foldseek Assets
     // =========================================

--- a/workflows/annotate.nf
+++ b/workflows/annotate.nf
@@ -14,9 +14,8 @@ nextflow.enable.dsl = 2
 // PARAMETERS
 // ===============================================
 // Output directory
+params.results_dir = params.results_dir ?: "${workflow.launchDir}/results/${params.project_name}"
 params.publish_mode = 'copy'
-params.results_dir = params.results_dir ?: "${workflow.launchDir}/results/${params.project_name ?: 'undefined_project'}"
-params.reports_dir = params.reports_dir ?: "${workflow.launchDir}/reports/${params.project_name ?: 'undefined_project'}"
 
 // ===============================================
 // MODULE IMPORTS

--- a/workflows/annotate.nf
+++ b/workflows/annotate.nf
@@ -14,7 +14,6 @@ nextflow.enable.dsl = 2
 // PARAMETERS
 // ===============================================
 // Output directory
-params.results_dir = "${workflow.launchDir}/results/${params.project_name}"
 params.publish_mode = 'copy'
 
 // ===============================================
@@ -179,6 +178,7 @@ def validateParameters() {
     Min chain residues  : ${params.min_chain_residues}
     Max entries (debug) : ${params.max_entries ?: 'N/A'}
     Results dir         : ${params.results_dir}
+    Reports dir         : ${params.reports_dir}
     Debug mode          : ${params.debug}
     ----------------------------------------------
     Foldseek Configuration Information
@@ -200,6 +200,10 @@ workflow {
     
     validateParameters()
     
+    // make sure results and reports directories exist
+    file(params.results_dir).mkdirs()
+    file(params.reports_dir).mkdirs()
+
     // =========================================
     // PHASE 0: Setup Foldseek Assets
     // =========================================


### PR DESCRIPTION
Fixes several issues encountered when running the pipeline on the CS cluster.

Changes:
- defines params.results_dir as a true value (params.results_dir ?: "${launchDir}/reports") in nextflow.config
- and removed ?: "${launchDir}/reports"} from the repots settings
- run create_input_from_zip, chunk_by_zip, light_chunk_consensus_by_zip, run_plddt, join_plddt_md5 and benchmark_compare_results locally with scratch disabled
- ensure benchmark_compare_results always writes benchmark_differences.tsv when result files differ (exit status 1 from diff is treated as an expected comparison result)

These changes were tested on the CS cluster using benchmark_154 and the 300K AFDB test run.