### PR TITLE
symlinks create_input_from_zip and binds params.input_zip_dir

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -19,10 +19,6 @@ process {
     // nothing falls back to Nextflow's implicit unset-memory default.
     cpus   = 1
     memory = { 4.GB * task.attempt }
-    
-    withName: run_domain_quality {
-        memory = { 8.GB * task.attempt }
-    }
 
     // ---------- CORRECTNESS CONSTRAINT (do not remove) ----------
     // chunk_ids_by_zip (aliased chunk_by_zip / heavy_chunk_by_zip) and

--- a/conf/base.config
+++ b/conf/base.config
@@ -18,7 +18,11 @@ process {
     // Basic floor: every module gets these unless a profile raises them, so
     // nothing falls back to Nextflow's implicit unset-memory default.
     cpus   = 1
-    memory = { 2.GB * task.attempt }
+    memory = { 4.GB * task.attempt }
+    
+    withName: run_domain_quality {
+        memory = { 8.GB * task.attempt }
+    }
 
     // ---------- CORRECTNESS CONSTRAINT (do not remove) ----------
     // chunk_ids_by_zip (aliased chunk_by_zip / heavy_chunk_by_zip) and

--- a/conf/base.config
+++ b/conf/base.config
@@ -18,7 +18,7 @@ process {
     // Basic floor: every module gets these unless a profile raises them, so
     // nothing falls back to Nextflow's implicit unset-memory default.
     cpus   = 1
-    memory = { 4.GB * task.attempt }
+    memory = { 2.GB * task.attempt }
 
     // ---------- CORRECTNESS CONSTRAINT (do not remove) ----------
     // chunk_ids_by_zip (aliased chunk_by_zip / heavy_chunk_by_zip) and

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -5,6 +5,10 @@ docker {
 
 process {
 
+    withName: run_domain_quality {
+        memory = { 8.GB * task.attempt }
+    }
+    
     withName: run_ted_chainsaw {
         memory = { params.project_name == 'git_actions_test' ? 14.GB : 16.GB }
         cpus = 2

--- a/conf/myriad_cluster.config
+++ b/conf/myriad_cluster.config
@@ -13,7 +13,6 @@ executor {
 process {
 
     cache     = 'lenient'
-    stageInMode  = 'copy'
     stageOutMode = 'copy'
 
     beforeScript = '''

--- a/conf/orengo.config
+++ b/conf/orengo.config
@@ -29,8 +29,7 @@ executor {
 process {
 
     cache = 'lenient'
-    stageInMode = 'copy'
-    stageOutMode = 'copy'
+    stageOutMode = 'copy' // Keeping just to ensure files are copied back from scratch space
 
     beforeScript = '''
     echo "========== TASK START =========="
@@ -109,5 +108,5 @@ singularity {
     envWhitelist = 'CUDA_VISIBLE_DEVICES,SINGULARITYENV_CUDA_VISIBLE_DEVICES'
 
     // note: will need to override this if scratch_dir is false (cannot use a closure here)
-    runOptions   = "--bind ${launchDir}:/launchDir:ro --bind ${params.scratch_dir}"
+    runOptions   = "--bind ${launchDir}:/launchDir:ro --bind ${params.scratch_dir} --bind ${params.input_zip_dir}"
 }


### PR DESCRIPTION
Adds two clauses to cs_cluster.config to allow process create_input_from_zip to use symlinks instead of copying a full directory of actual files.