### PR TITLE
CS cluster config fix

### DIFF
--- a/conf/cs_cluster.config
+++ b/conf/cs_cluster.config
@@ -22,7 +22,7 @@ singularity {
 process {
     scratch  = false                       // run on shared /SAN — always correct, no vanishing paths
     executor = 'sge'
-    beforeScript = "mkdir -p /scratch0/${System.getenv('USER')}/"
+    beforeScript = { task.executor == 'local' ? '' : "mkdir -p /scratch0/${System.getenv('USER')}/" }
     scratch = "/scratch0/${System.getenv('USER')}/"
     penv     = { task.cpus > 1 ? 'smp' : null }
 


### PR DESCRIPTION
Hi @sillitoe @NSEdmunds, I had to make a small change con the `cs_config` file since it was still trying to use scratch even in those processes that are now run locally.

It was only that file and that line. No issues with the `orengo.config`.

Should be ready to be merged right away.